### PR TITLE
adicionei o exercicio 043_bcdadd100

### DIFF
--- a/hdlbits/043_bcdadd100.txt
+++ b/hdlbits/043_bcdadd100.txt
@@ -1,0 +1,18 @@
+module top_module( 
+    input [399:0] a, b,
+    input cin,
+    output cout,
+    output [399:0] sum );
+	
+    wire[99:0] cout_wires;
+    genvar i;
+    
+    generate
+        bcd_fadd(a[3:0], b[3:0], cin, cout_wires[0],sum[3:0]);
+        for (i=4; i<400; i=i+4) begin: bcd_adder_instances
+            bcd_fadd bcd_adder(a[i+3:i], b[i+3:i], cout_wires[i/4-1],cout_wires[i/4],sum[i+3:i]);
+        end
+    endgenerate
+    
+    assign cout = cout_wires[99];
+endmodule


### PR DESCRIPTION
O programa soma 100 dígitos BCD utilizando vetores de 400 bits. Para isso, a variável genvar é utilizada no loop generate-for para iterar valores de 4 em 4 ea varrer os dígitos, armazenando o valor na variável cout_wires, de tamanho 100.