### PR TITLE
feat: portabilidade pra outras distro sem ser Ubuntu

### DIFF
--- a/labs/setup.sh
+++ b/labs/setup.sh
@@ -1,2 +1,21 @@
-sudo apt update; sudo apt install iverilog
+#!/usr/bin/env bash
+# Instala as ferramentas de simulação (Icarus Verilog e GTKWave).
+# Detecta automaticamente o gerenciador de pacotes da distribuição.
+set -e
 
+PACOTES="iverilog gtkwave"
+
+if command -v apt >/dev/null 2>&1; then          # Debian, Ubuntu, Mint, ...
+    sudo apt update
+    sudo apt install -y $PACOTES
+elif command -v pacman >/dev/null 2>&1; then     # Arch, Manjaro, EndeavourOS, ...
+    sudo pacman -Syu --needed --noconfirm $PACOTES
+elif command -v dnf >/dev/null 2>&1; then        # Fedora, RHEL, Rocky, ...
+    sudo dnf install -y $PACOTES
+elif command -v zypper >/dev/null 2>&1; then     # openSUSE
+    sudo zypper install -y $PACOTES
+else
+    echo "Gerenciador de pacotes não reconhecido."
+    echo "Instale manualmente os pacotes: $PACOTES"
+    exit 1
+fi


### PR DESCRIPTION
adicionei um detector de gerenciador de pacotes, fazendo com que o script setup.sh rode em distribuições Arch, Fedora, e openSUSE sem problemas